### PR TITLE
Kc installation fixes

### DIFF
--- a/deploy/mediacms.io
+++ b/deploy/mediacms.io
@@ -58,9 +58,9 @@ server {
 
     error_log  /var/log/nginx/mediacms.io.error.log  warn;
 
-    location /static {
-        alias /home/mediacms.io/mediacms/static ;
-    }
+location /static {
+    alias /home/cinemata/cinematacms/static ;
+}
 
     location /media/original {
         alias /home/cinemata/cinematacms/media_files/original;

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -1,13 +1,11 @@
 [Unit]
-Description=uwsgi mediacms.io
+Description=uwsgi cinemata
 
 [Service]
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini
 ExecStop=/usr/bin/killall -9 uwsgi
 RestartSec=3
-#ExecRestart=killall -9 uwsgi; sleep 5; /home/sss/bin/uwsgi --ini /home/sss/wordgames/uwsgi.ini
 Restart=always
-
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/config/installation/site.html
+++ b/templates/config/installation/site.html
@@ -5,11 +5,11 @@ MediaCMS.site = {
     api: '{{FRONTEND_HOST}}/api/v1',
     topmessage: '{{TOP_MESSAGE}}',
     theme: {
-        mode: 'dark',    // Valid values: 'light', 'dark'.
-        switch: {
-            position: 'sidebar',    // Valid values: 'header', 'sidebar'.
-        },
+    mode: 'light',    // Valid values: 'light', 'dark'.
+    switch: {
+        position: 'sidebar',    // Valid values: 'header', 'sidebar'.
     },
+},
     logo:{
         lightMode:{
             img: "{{FRONTEND_HOST}}/static/images/cinemata_logo-darkbg.jpg",

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,27 +1,24 @@
 [uwsgi]
 
-chdir           = /home/mediacms.io/mediacms/
-virtualenv = /home/mediacms.io
+chdir           = /home/cinemata/cinematacms/
+virtualenv = /home/cinemata
 module          = cms.wsgi
 
 uid=www-data
 gid=www-data
 
-processes = 4
-threads = 4
+processes = 10
+threads = 10
 
 master          = true
 
 socket = 127.0.0.1:9000
-#socket = /home/mediacms.io/mediacms/deploy/uwsgi.sock
 
-
-workers = 4
-
+workers = 8
+master = true
 
 vacuum          = true
 
-logto = /home/mediacms.io/mediacms/logs/errorlog.txt
+logto = /home/cinemata/cinematacms/logs/errorlog.txt
 
 disable-logging = true
-


### PR DESCRIPTION
This PR fixes path inconsistencies in the installation files that were causing 502 errors. 

The main issues were:
- uwsgi.ini was pointing to /home/mediacms.io/ paths instead of /home/cinemata/
- Service files had incorrect paths
- NGINX configuration referenced wrong locations

These changes ensure all paths consistently use /home/cinemata/cinematacms/