### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1002,14 +1002,20 @@ def task_sent_handler(sender=None, headers=None, body=None, **kwargs):
     return True
 
 
+import shlex
+
 def kill_ffmpeg_process(filepath):
-    # this is not ideal, ffmpeg pid could be linked to the Encoding object
-    cmd = "ps aux|grep 'ffmpeg'|grep %s|grep -v grep |awk '{print $2}'" % filepath
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, shell=True)
+    # Validate the filepath to ensure it is a valid file path
+    if not os.path.isfile(filepath):
+        raise ValueError("Invalid file path")
+
+    # Use shlex.split to safely construct command arguments
+    cmd = f"ps aux | grep 'ffmpeg' | grep {shlex.quote(filepath)} | grep -v grep | awk '{{print $2}}'"
+    result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
     pid = result.stdout.decode("utf-8").strip()
     if pid:
-        cmd = "kill -9 %s" % pid
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, shell=True)
+        cmd = f"kill -9 {pid}"
+        result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
     return result
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/EngageMedia-Tech/cinematacms/security/code-scanning/1](https://github.com/EngageMedia-Tech/cinematacms/security/code-scanning/1)

To fix the problem, we need to ensure that the `filepath` value used in the `cmd` string is properly sanitized and validated. One way to achieve this is by using a more secure method to construct and execute the command, such as using the `shlex` module to safely split the command string into a list of arguments. Additionally, we should validate the `filepath` to ensure it is a valid file path and does not contain any malicious content.

1. Import the `shlex` module to safely split the command string.
2. Validate the `filepath` to ensure it is a valid file path.
3. Use `shlex.split` to construct the command arguments safely.
4. Update the `kill_ffmpeg_process` function to use the validated and sanitized `filepath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
